### PR TITLE
fix 'Doxygen API documentation' link

### DIFF
--- a/pages/resources.html
+++ b/pages/resources.html
@@ -79,7 +79,7 @@ OSS-7            </a>
 <li><a href="http://www.slideshare.net/MaartenWeyn1/dash7-alliance-protocol-technical-presentation">Presentation about DASH7 on slideshare</a></li>
 <li><a href="http://www.hindawi.com/journals/ijdsn/2013/870430/">Journal paper: Survey of the DASH7 Alliance Protocol for 433 MHz Wireless Sensor Communication</a></li>
 <li>The DASH 7 Alliance Protocol specification is available for download <a href="http://www.dash7.org/specifications">here</a></li>
-<li><a href="{filename}/doxygen">Doxygen API documentation</a></li>
+<li><a href="http://cosys-lab.github.io/dash7-ap-open-source-stack/doxygen/">Doxygen API documentation</a></li>
 <li>Subscribe to our RSS feed to <a href="./feeds/all.atom.xml">follow us</a></li>
 </ul>
         </div>


### PR DESCRIPTION
{filename}/doxygen is not tranformed, replaced with absolute path like the other API links use