### PR TITLE
Update wizzimote_leds.c

### DIFF
--- a/stack/framework/hal/platforms/wizzimote/wizzimote_leds.c
+++ b/stack/framework/hal/platforms/wizzimote/wizzimote_leds.c
@@ -37,7 +37,7 @@ void __led_init()
 {
     leds[0] = P1_7;
     leds[1] = P3_7;
-    leds[1] = P3_6;
+    leds[2] = P3_6;
     for(int i = 0; i < HW_NUM_LEDS; i++)
     {
         error_t err = hw_gpio_configure_pin(leds[i], GPIO_MODE_OUTPUT);


### PR DESCRIPTION
Only LED0 and LED1 worked ( as red and green), now LED0 is red, LED1 is orange and LED2 is green.